### PR TITLE
fix: config typo and small memory fix in extnotes.c

### DIFF
--- a/apps/download/tailwind.config.js
+++ b/apps/download/tailwind.config.js
@@ -22,7 +22,7 @@ module.exports = {
     fontFamily: {
       display: ['Lexend', '"Red Hat Text"', ...sans],
       body: ['"Red Hat Text"', ...sans],
-      mono: ['"Ubunto Mono"', ...mono]
+      mono: ['"Ubuntu Mono"', ...mono]
     }
   },
   variants: {},

--- a/cook/extnotes.c
+++ b/cook/extnotes.c
@@ -27,12 +27,14 @@
 /* NOTE: This program assumes little-endian for speed, it WILL NOT WORK on a
  * big-endian system */
 
-struct OggPreHeader {
+struct OggPreHeader
+{
     unsigned char capturePattern[4];
     unsigned char version;
 } __attribute__((packed));
 
-struct OggHeader {
+struct OggHeader
+{
     unsigned char type;
     uint64_t granulePos;
     uint32_t streamNo;
@@ -42,11 +44,13 @@ struct OggHeader {
 
 ssize_t readAll(int fd, void *vbuf, size_t count)
 {
-    unsigned char *buf = (unsigned char *) vbuf;
+    unsigned char *buf = (unsigned char *)vbuf;
     ssize_t rd = 0, ret;
-    while (rd < count) {
+    while (rd < count)
+    {
         ret = read(fd, buf + rd, count - rd);
-        if (ret <= 0) return ret;
+        if (ret <= 0)
+            return ret;
         rd += ret;
     }
     return rd;
@@ -55,30 +59,32 @@ ssize_t readAll(int fd, void *vbuf, size_t count)
 void printNote(unsigned char *buf, uint32_t packetSize)
 {
     int i;
-    for (i = 4; i < packetSize; i++) {
-        switch (buf[i]) {
-            case '"':
-            case '\\':
-                printf("\\%c", buf[i]);
-                break;
+    for (i = 4; i < packetSize; i++)
+    {
+        switch (buf[i])
+        {
+        case '"':
+        case '\\':
+            printf("\\%c", buf[i]);
+            break;
 
-            case '\n':
-                printf("\\n");
-                break;
+        case '\n':
+            printf("\\n");
+            break;
 
-            case '\r':
-                printf("\\r");
-                break;
+        case '\r':
+            printf("\\r");
+            break;
 
-            default:
-                putchar(buf[i]);
+        default:
+            putchar(buf[i]);
         }
     }
 }
 
 int main(int argc, char **argv)
 {
-    uint32_t noteStreamNo = (uint32_t) -1;
+    uint32_t noteStreamNo = (uint32_t)-1;
     uint32_t packetSize;
     unsigned char segmentCount, segmentVal;
     unsigned char *buf = NULL;
@@ -87,15 +93,19 @@ int main(int argc, char **argv)
     unsigned char outputAudacity = 0, outputJSON = 0, outputHeader = 0;
     int ai;
 
-    for (ai = 1; ai < argc; ai++) {
+    for (ai = 1; ai < argc; ai++)
+    {
         char *arg = argv[ai];
-        if (!strcmp(arg, "-f") || !strcmp(arg, "--format")) {
+        if (!strcmp(arg, "-f") || !strcmp(arg, "--format"))
+        {
             arg = argv[++ai];
             if (arg && !strcmp(arg, "audacity"))
                 outputAudacity = 1;
             if (arg && !strcmp(arg, "json"))
                 outputJSON = 1;
-        } else {
+        }
+        else
+        {
             fprintf(stderr, "Use: extnotes [--format audacity|-f audacity|--format json|-f json]\n");
             exit(1);
         }
@@ -104,7 +114,8 @@ int main(int argc, char **argv)
     if (outputJSON)
         printf("[");
 
-    while (readAll(0, &preHeader, sizeof(preHeader)) == sizeof(preHeader)) {
+    while (readAll(0, &preHeader, sizeof(preHeader)) == sizeof(preHeader))
+    {
         struct OggHeader oggHeader;
         double time;
         if (memcmp(preHeader.capturePattern, "OggS", 4))
@@ -118,17 +129,23 @@ int main(int argc, char **argv)
         packetSize = 0;
         if (readAll(0, &segmentCount, 1) != 1)
             break;
-        for (; segmentCount; segmentCount--) {
+        for (; segmentCount; segmentCount--)
+        {
             if (readAll(0, &segmentVal, 1) != 1)
                 break;
-            packetSize += (uint32_t) segmentVal;
+            packetSize += (uint32_t)segmentVal;
         }
 
         // Get the data
-        if (packetSize > bufSz) {
-            buf = realloc(buf, packetSize);
-            if (!buf)
+        if (packetSize > bufSz)
+        {
+            unsigned char *temp = realloc(buf, packetSize); // Use a temporary pointer
+            if (!temp)
+            {              // Check if memory allocation failed
+                free(buf); // Free the existing buffer to avoid a memory leak
                 break;
+            }
+            buf = temp; // Only assign buf if realloc was successful
             bufSz = packetSize;
         }
         if (readAll(0, buf, packetSize) != packetSize)
@@ -137,7 +154,7 @@ int main(int argc, char **argv)
         // Check for headers
         if (oggHeader.granulePos == 0 && packetSize == 10 && !memcmp(buf, "STREAMNOTE", 10))
             noteStreamNo = oggHeader.streamNo;
-        else if (noteStreamNo == (uint32_t) -1 && oggHeader.granulePos > 0)
+        else if (noteStreamNo == (uint32_t)-1 && oggHeader.granulePos > 0)
             break;
 
         // Do we care?
@@ -151,8 +168,10 @@ int main(int argc, char **argv)
         time = oggHeader.granulePos / 48000.0;
 
         // Now output this line
-        if (outputAudacity) {
-            if (!outputHeader) {
+        if (outputAudacity)
+        {
+            if (!outputHeader)
+            {
                 // Header first
                 printf("\t<labeltrack name=\"Label Track\" height=\"73\" minimized=\"0\">\n");
                 outputHeader = 1;
@@ -162,21 +181,28 @@ int main(int argc, char **argv)
             printf("\t\t<label t=\"%f\" t1=\"%f\" title=\"", time, time);
             printNote(buf, packetSize);
             printf("\"/>\n");
-
-        } else if (outputJSON) {
-            if (outputHeader) {
+        }
+        else if (outputJSON)
+        {
+            if (outputHeader)
+            {
                 // Add comma before next note
                 printf(",");
-            } else {
+            }
+            else
+            {
                 outputHeader = 1;
             }
 
             printf("{\"time\":\"%f\",\"note\":\"", time, time);
             printNote(buf, packetSize);
             printf("\"}");
-        } else {
+        }
+        else
+        {
             int h, m;
-            if (!outputHeader) {
+            if (!outputHeader)
+            {
                 printf("Notes:\r\n");
                 outputHeader = 1;
             }
@@ -184,8 +210,8 @@ int main(int argc, char **argv)
             time -= h * 3600;
             m = time / 60.0;
             time -= m * 60;
-            printf("\t%d:%02d:%02d: ", h, m, (int) time);
-            printNote(buf, packetSize); 
+            printf("\t%d:%02d:%02d: ", h, m, (int)time);
+            printNote(buf, packetSize);
             printf("\r\n");
         }
     }


### PR DESCRIPTION
Fix Typos and Enhance Memory Management in tailwind.config.js and extnotes.c

1. **Typographical Error**:
   - **File**: tailwind.config.js
   - **Issue**:  a type error
   
                      mono: ['"Ubunto Mono"', ...mono]

   - **Solution**:
    
                       mono: ['"Ubuntu Mono"', ...mono]
 
   - It ensures proper recognition of the font, improving the overall aesthetic consistency of the application.

2. **Memory Management Improvement**:
   - **File**: extnotes.c
   - **Issue**: The original code did not safely handle the result of `realloc`. If `realloc` failed, it could lead to memory leaks since 
        the original pointer would be lost.
   - **Solution**: Introduced a temporary pointer (`temp`) to hold the result of `realloc`. This ensures that if `realloc` fails, the 
       original buffer remains intact and can be freed properly.

   The updated code now checks the allocation:
     ``` // Get the data
        if (packetSize > bufSz)
        {
            unsigned char *temp = realloc(buf, packetSize); // Use a temporary pointer
            if (!temp)
            {              // Check if memory allocation failed
                free(buf); // Free the existing buffer to avoid a memory leak
                break;
            }
            buf = temp; // Only assign buf if realloc was successful
            bufSz = packetSize;
        }; 
    ```

These changes aim to enhance the reliability and performance of the application by correcting minor bugs and improving memory safety. 

Hey @Snazzah assign this under the [hacktoberfest2024) :) !!