### PR TITLE
Update install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,22 +7,23 @@ set -e
 ###################################################
 
 APT_DEPENDENCIES=(
-  make            # cook
-  inkscape        # cook
-  ffmpeg          # cook
-  flac            # cook
-  fdkaac          # cook
-  vorbis-tools    # cook
-  opus-tools      # cook
-  zip             # cook
-  unzip           # cook
-  lsb-release     # redis
-  curl            # redis
-  gpg             # redis
-  postgresql      # web
-  sed             # install
-  coreutils       # install
-  build-essential # install
+  make              # cook
+  inkscape          # cook
+  ffmpeg            # cook
+  flac              # cook
+  fdkaac            # cook
+  vorbis-tools      # cook
+  opus-tools        # cook
+  zip               # cook
+  unzip             # cook
+  lsb-release       # redis
+  curl              # redis
+  gpg               # redis
+  postgresql        # web
+  sed               # install
+  coreutils         # install
+  build-essential   # install
+  python-setuptools # install
 )
 
 # Get the directory of the script being executed


### PR DESCRIPTION
The core issue is the missing distutils Python module, which is required by node-gyp (used to compile native addons).  distutils has been deprecated and removed from Python's standard library since Python 3.12.  

- Best regards
Some assistance from Gemini:
![image](https://github.com/user-attachments/assets/7b68753a-9ecb-43b2-8b5c-dd8d7881f367)


Ubuntu 24.04 for example ships with 3.12...