### PR TITLE
Add the dbus-x11 dependency to the install.sh file APT_DEPENDENCIES

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -20,6 +20,7 @@ APT_DEPENDENCIES=(
   curl              # redis
   gpg               # redis
   postgresql        # web
+  dbus-x11          # install
   sed               # install
   coreutils         # install
   build-essential   # install


### PR DESCRIPTION
The install script does not work on Ubuntu 22.4 because dbus-11 is missing, as it does not comes with Ubuntu 22.4 by default in a fresh install. An "apt install dbus-x11" can fix this, so that's why I'm proposing for dbus-x11 to be added into the install script.