### PR TITLE
feat: recording webhook

### DIFF
--- a/apps/bot/config/_default.js
+++ b/apps/bot/config/_default.js
@@ -85,6 +85,9 @@ module.exports = {
       hardLimitWeb: 4294967296,
       // Whether to remove the nickname after finishing the recording
       removeNickname: true,
+      // DFL: Webhook URL to call when a recording ends (optional)
+      recordingWebhookURL: '',
+      recordingWebhookSecret: '',
       // Whether to recognize alistair emojis instead of craig emojis
       alistair: false,
       // The folder to put recordings in

--- a/apps/bot/src/bot.ts
+++ b/apps/bot/src/bot.ts
@@ -53,6 +53,9 @@ export interface CraigBotConfig extends BaseConfig {
     };
     rewardTiers: { [tier: string]: RewardTier };
     entitlementWebhookURLs?: { url: string; key: string }[];
+    // DFL: URL to notify when a recording ends (optional)
+    recordingWebhookURL?: string;
+    recordingWebhookSecret?: string;
   };
 
   logger: {

--- a/apps/bot/src/modules/recorder/recording.ts
+++ b/apps/bot/src/modules/recorder/recording.ts
@@ -378,10 +378,47 @@ export default class Recording {
 
       if (this.started)
         await this.uploadToDrive().catch((e) => this.recorder.logger.error(`Failed to upload recording ${this.id} to ${this.user.id}`, e));
+
+      if (this.started) await this.notifyWebhook();
     } catch (e) {
       // This is pretty bad, make sure to clean up any reference
       this.recorder.logger.error(`Failed to stop recording ${this.id} by ${this.user.username}#${this.user.discriminator} (${this.user.id})`, e);
       this.recorder.recordings.delete(this.channel.guild.id);
+    }
+  }
+
+  async notifyWebhook() {
+    const { recordingWebhookURL, recordingWebhookSecret, downloadProtocol, downloadDomain } = this.recorder.client.config.craig;
+    if (!recordingWebhookURL) return;
+
+    const downloadUrl = `${downloadProtocol ?? 'https'}://${downloadDomain}/rec/${this.id}?key=${this.accessKey}`;
+
+    const payload = {
+      id: this.id,
+      accessKey: this.accessKey,
+      downloadUrl,
+      guild: this.channel.guild.name,
+      guildId: this.channel.guild.id,
+      channel: this.channel.name,
+      channelId: this.channel.id,
+      requester: this.user.discriminator === '0' ? this.user.username : `${this.user.username}#${this.user.discriminator}`,
+      requesterId: this.user.id,
+      startedAt: this.startedAt?.toISOString() ?? null,
+      endedAt: new Date().toISOString()
+    };
+
+    try {
+      await fetch(recordingWebhookURL, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(recordingWebhookSecret ? { 'x-webhook-secret': recordingWebhookSecret } : {})
+        },
+        body: JSON.stringify(payload)
+      });
+      this.recorder.logger.info(`[webhook] Notified recording end for ${this.id}`);
+    } catch (e) {
+      this.recorder.logger.error(`[webhook] Failed to notify recording end for ${this.id}`, e);
     }
   }
 


### PR DESCRIPTION
## O que foi feito

Adiciona suporte a webhook quando uma gravação termina. Ao final do `stop()`, o Craig faz um `POST` para uma URL configurável com os dados da gravação.

## Payload enviado

```json
{
  "id": "recordingId",
  "accessKey": "accessKey",
  "downloadUrl": "https://<downloadDomain>/rec/<id>?key=<accessKey>",
  "guild": "Nome do servidor",
  "guildId": "123456789",
  "channel": "Nome do canal",
  "channelId": "987654321",
  "requester": "usuario#0000",
  "requesterId": "111222333",
  "startedAt": "2026-05-09T00:00:00.000Z",
  "endedAt": "2026-05-09T01:00:00.000Z"
}
```

## Como configurar (config/_default.js ou override)

```js
craig: {
  recordingWebhookURL: 'https://<bot-server>/webhook/craig',
  recordingWebhookSecret: 'seu-secret',
}
```

## Arquivos modificados
- `apps/bot/src/bot.ts` — adicionado `recordingWebhookURL` e `recordingWebhookSecret` na interface
- `apps/bot/config/_default.js` — campos com valor padrão vazio
- `apps/bot/src/modules/recorder/recording.ts` — método `notifyWebhook()` chamado no `stop()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)