### PR TITLE
fix(devcontainer): add pm2 to global npm modules install

### DIFF
--- a/.devcontainer/post-create-command.sh
+++ b/.devcontainer/post-create-command.sh
@@ -11,7 +11,7 @@ VSC_REDIS_CLIENT=data/User/globalStorage/cweijan.vscode-redis-client
 npm i -g pnpm@10.33.4
 
 # Install global modules
-sudo npm i -g turbo slash-up prisma tsx
+sudo npm i -g turbo slash-up prisma tsx pm2
 
 # Create folders
 [ -d rec ] || mkdir rec


### PR DESCRIPTION
Add PM2 to the list of npm modules installed in the devcontainer after it is created. 

Without PM2, core commands such as `pnpm bot-instance` (which use PM2 under the hood) do not work, for obvious reasons. It can be installed manually, but since the point of a devcontainer is to set up a complete (and reproducible) dev environment with minimal manual interaction, it would make sense to automate this step.